### PR TITLE
Support unicode mapping

### DIFF
--- a/src/Noscrape.php
+++ b/src/Noscrape.php
@@ -70,21 +70,12 @@ class Noscrape {
         return $s;
     }
 
-    private function str_split_unicode(string $s): array {
-        $len = mb_strlen($s, 'UTF-8');
-        $result = [];
-        for ($i = 0; $i < $len; $i++) {
-            $result[] = mb_substr($s, $i, 1, 'UTF-8');
-        }
-        return $result;
-    }
-
     private function obfuscateString(string $s): string {
         // Available characters are those in the PUA range that haven't been mapped yet
         $availableChars = array_diff($this->puaRange, array_values($this->mapping));
 
         $obfuscated = '';
-        foreach ($this->str_split_unicode($s) as $c) {
+        foreach (mb_str_split($s) as $c) {
             // If the character hasn't been mapped yet, map it to a random available PUA character
             if (!isset($this->mapping[$c])) {
                 $randomIndex = array_rand($availableChars);

--- a/src/Noscrape.php
+++ b/src/Noscrape.php
@@ -111,6 +111,6 @@ class Noscrape {
         ]);
 
         // Execute the rendering command and return the output
-        return shell_exec( "{$binary} '{$param}'");
+        return trim(shell_exec("{$binary} '{$param}'"));
     }
 }

--- a/src/Noscrape.php
+++ b/src/Noscrape.php
@@ -70,12 +70,21 @@ class Noscrape {
         return $s;
     }
 
+    private function str_split_unicode(string $s): array {
+        $len = mb_strlen($s, 'UTF-8');
+        $result = [];
+        for ($i = 0; $i < $len; $i++) {
+            $result[] = mb_substr($s, $i, 1, 'UTF-8');
+        }
+        return $result;
+    }
+
     private function obfuscateString(string $s): string {
         // Available characters are those in the PUA range that haven't been mapped yet
         $availableChars = array_diff($this->puaRange, array_values($this->mapping));
 
         $obfuscated = '';
-        foreach (str_split($s) as $c) {
+        foreach ($this->str_split_unicode($s) as $c) {
             // If the character hasn't been mapped yet, map it to a random available PUA character
             if (!isset($this->mapping[$c])) {
                 $randomIndex = array_rand($availableChars);


### PR DESCRIPTION
`str_split` is not unicode friendly, so obfuscating non-ascii will break.
Note that mbstring needs to be installed to support Unicode..
